### PR TITLE
Add Claude coding subagent runtime (Anthropic SDK) with interactive support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Main Agent: "Done! The script is saved as hn_scraper.py..."  ← announces resul
 
 ## Features
 
-- **Background subagents**: Mark any tool as `execution: 'background'` — it hands off to a Vercel AI SDK subagent with its own tool-use loop (`maxSteps`), running in parallel while the voice agent continues the conversation. Subagents can be **interactive** — asking the user follow-up questions via voice mid-task
+- **Background subagents**: Mark any tool as `execution: 'background'` — it hands off to a Vercel AI SDK subagent with its own tool-use loop (`maxSteps`), running in parallel while the voice agent continues the conversation. Subagents can be **interactive** — asking the user follow-up questions via voice. Runtime options include the default Vercel AI SDK and a Claude coding runtime via `claude-agent-sdk-python` mid-task
 - **Real-time voice**: Bidirectional audio streaming with Gemini Live API, server-side VAD and turn detection
 - **Multi-agent transfers**: Define specialist agents with distinct personas and tools; transfer mid-conversation with context replay and audio buffering
 - **Inline + background tools**: `inline` tools block the turn (fast lookups); `background` tools run async (image/video generation, data analysis)

--- a/docs/advanced/claude-coding-subagent.md
+++ b/docs/advanced/claude-coding-subagent.md
@@ -1,0 +1,46 @@
+# Claude Coding Subagent (Anthropic SDK) — Capability Assessment
+
+This document captures what the framework can support today by integrating `claude-agent-sdk-python`, and what is currently out-of-scope.
+
+## What is supported
+
+- **Interactive multi-turn coding handoff from MainAgent → Claude subagent.**
+  - A background tool can hand off work to a Claude runtime subagent (`runtime: 'claude_code'`).
+  - The subagent can ask follow-up questions (`status: needs_input`) and receive spoken user input through the existing interactive subagent session.
+
+- **Stateful continuation across turns.**
+  - The implementation persists Claude `session_id` between turns and resumes conversation when user clarification is required.
+
+- **Tool permission controls.**
+  - You can configure `permissionMode` and `allowedTools` via `SubagentConfig.claude`.
+
+- **Working directory and model controls.**
+  - You can configure `cwd`, `model`, `maxTurns`, and Python binary path.
+
+- **No custom Claude CLI install required (by default).**
+  - Integration uses Python SDK and relies on bundled CLI behavior in `claude-agent-sdk-python`.
+
+## What is not fully supported (yet)
+
+- **Live token-by-token relay from Claude to voice user.**
+  - Current bridge returns a turn-level result, not incremental stream updates.
+
+- **Native Claude-side tool hook/mcp wiring from TypeScript directly.**
+  - Python SDK supports hooks and SDK MCP servers, but this framework bridge currently only maps core coding-turn options.
+
+- **Interrupt/resume controls surfaced through framework APIs.**
+  - The Python SDK client supports interrupt operations; this initial integration uses request/response turn execution.
+
+- **Usage/cost telemetry mapping into framework step metrics.**
+  - Framework `onSubagentStep` currently records step count, but not Claude token/cost metadata.
+
+- **Strict guarantee on “needs_input” detection without JSON contract compliance.**
+  - Bridge requests structured JSON output (`completed|needs_input`). If model output violates schema, fallback behavior is best-effort.
+
+## Recommended next improvements
+
+1. Add stream event relay (partial output/progress) into `SubagentMessage`.
+2. Add explicit `interruptSubagent` support for Claude runtime.
+3. Expose richer `claude` config (hooks, MCP servers, sandbox, budget caps).
+4. Pipe Claude usage/cost into framework telemetry.
+5. Add conformance tests that simulate malformed structured output.

--- a/docs/advanced/subagents.md
+++ b/docs/advanced/subagents.md
@@ -184,6 +184,31 @@ Events can be `normal` or `urgent`:
 | `normal` | Notification queued, delivered at next turn boundary |
 | `urgent` | May interrupt the current turn to notify immediately |
 
+
+## Claude Coding Runtime
+
+In addition to the default Vercel AI SDK subagent runtime, you can run a subagent with Anthropic's `claude-agent-sdk-python` by setting `runtime: "claude_code"`:
+
+```typescript
+const claudeCodingSubagent: SubagentConfig = {
+  name: 'claude_coder',
+  runtime: 'claude_code',
+  interactive: true,
+  instructions: 'You are a senior coding agent. Ask concise clarifying questions when needed.',
+  tools: {}, // Not used by claude_code runtime
+  maxSteps: 8,
+  claude: {
+    pythonBin: 'python3',
+    cwd: '/path/to/repo',
+    model: 'claude-sonnet-4-5',
+    permissionMode: 'acceptEdits',
+    allowedTools: ['Read', 'Write', 'Edit', 'Bash', 'Glob', 'Grep'],
+  },
+};
+```
+
+See `docs/advanced/claude-coding-subagent.md` for a full capability/limitation matrix.
+
 ## SubagentConfig Reference
 
 ```typescript
@@ -194,6 +219,15 @@ interface SubagentConfig {
   maxSteps?: number;      // Max LLM steps (default 5)
   timeout?: number;       // Execution timeout in ms
   model?: string;         // Override session model
+  runtime?: 'ai_sdk' | 'claude_code';
+  claude?: {
+    pythonBin?: string;
+    cwd?: string;
+    model?: string;
+    permissionMode?: 'default' | 'acceptEdits' | 'bypassPermissions';
+    allowedTools?: string[];
+    maxTurns?: number;
+  };
 }
 ```
 

--- a/src/agent/claude-subagent-runner.ts
+++ b/src/agent/claude-subagent-runner.ts
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: MIT
+
+import { spawn } from 'node:child_process';
+import { AgentError } from '../core/errors.js';
+import type { HooksManager } from '../core/hooks.js';
+import type { ClaudeCodingSubagentConfig } from '../types/agent.js';
+import type { SubagentContextSnapshot, SubagentResult } from '../types/conversation.js';
+import type { SubagentSession } from './subagent-session.js';
+
+const BRIDGE_PYTHON_CODE = String.raw`
+import asyncio
+import json
+import sys
+
+from claude_agent_sdk import ClaudeAgentOptions, query
+from claude_agent_sdk.types import AssistantMessage, ResultMessage, TextBlock
+
+
+async def run(payload: dict):
+    cfg = payload.get("config", {})
+    options = ClaudeAgentOptions(
+        system_prompt=(
+            payload.get("subagentInstructions", "")
+            + "\n\nYou must return strict JSON matching this schema:"
+            + '{"status":"completed|needs_input","message":"string","question":"string|null"}'
+            + "\nUse status=needs_input only if user input is required before you can continue."
+        ),
+        model=cfg.get("model"),
+        permission_mode=cfg.get("permissionMode"),
+        allowed_tools=cfg.get("allowedTools", []),
+        max_turns=cfg.get("maxTurns"),
+        cwd=cfg.get("cwd"),
+        continue_conversation=bool(payload.get("sessionId")),
+        resume=payload.get("sessionId"),
+        output_format={
+            "type": "json_schema",
+            "name": "subagent_response",
+            "schema": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "status": {"type": "string", "enum": ["completed", "needs_input"]},
+                    "message": {"type": "string"},
+                    "question": {"type": ["string", "null"]},
+                },
+                "required": ["status", "message", "question"],
+            },
+        },
+    )
+
+    assistant_text = ""
+    session_id = payload.get("sessionId")
+    structured_output = None
+
+    async for message in query(prompt=payload["prompt"], options=options):
+        if isinstance(message, AssistantMessage):
+            text_parts = [block.text for block in message.content if isinstance(block, TextBlock)]
+            if text_parts:
+                assistant_text = "\n".join(text_parts)
+        elif isinstance(message, ResultMessage):
+            session_id = message.session_id
+            if message.structured_output is not None:
+                structured_output = message.structured_output
+            elif message.result:
+                try:
+                    structured_output = json.loads(message.result)
+                except Exception:
+                    pass
+
+    return {
+        "sessionId": session_id,
+        "assistantText": assistant_text,
+        "structuredOutput": structured_output,
+        "isError": False,
+    }
+
+
+payload = json.loads(sys.argv[1])
+result = asyncio.run(run(payload))
+print(json.dumps(result))
+`;
+
+export interface RunClaudeSubagentOptions {
+	config: ClaudeCodingSubagentConfig;
+	context: SubagentContextSnapshot;
+	hooks: HooksManager;
+	abortSignal?: AbortSignal;
+	session?: SubagentSession;
+}
+
+interface ClaudeBridgeResponse {
+	sessionId?: string;
+	assistantText?: string;
+	structuredOutput?: { status?: string; message?: string; question?: string | null };
+	isError?: boolean;
+	error?: string;
+}
+
+function buildClaudeTaskPrompt(context: SubagentContextSnapshot): string {
+	const parts: string[] = [];
+	parts.push(`Task: ${context.task.description}`);
+	if (Object.keys(context.task.args).length > 0) {
+		parts.push(`Task arguments: ${JSON.stringify(context.task.args, null, 2)}`);
+	}
+	if (context.conversationSummary) {
+		parts.push(`Conversation summary: ${context.conversationSummary}`);
+	}
+	if (context.recentTurns.length > 0) {
+		parts.push(
+			`Recent turns:\n${context.recentTurns.map((t) => `[${t.role}] ${t.content}`).join('\n')}`,
+		);
+	}
+	parts.push(
+		'Solve the task. If you need clarification, set status="needs_input" and ask a concise question.',
+	);
+	return parts.join('\n\n');
+}
+
+async function runBridgeTurn(
+	input: {
+		prompt: string;
+		sessionId?: string;
+		config: ClaudeCodingSubagentConfig;
+	},
+	abortSignal?: AbortSignal,
+): Promise<ClaudeBridgeResponse> {
+	const pythonBin = input.config.claude?.pythonBin ?? 'python3';
+	const payload = JSON.stringify({
+		prompt: input.prompt,
+		sessionId: input.sessionId,
+		config: input.config.claude ?? {},
+		subagentInstructions: input.config.instructions,
+	});
+	const bridgePath = input.config.claude?.bridgeScriptPath;
+	const args = bridgePath ? [bridgePath, payload] : ['-c', BRIDGE_PYTHON_CODE, payload];
+
+	return new Promise<ClaudeBridgeResponse>((resolve, reject) => {
+		const child = spawn(pythonBin, args, {
+			cwd: input.config.claude?.cwd,
+			stdio: ['ignore', 'pipe', 'pipe'],
+		});
+		let stdout = '';
+		let stderr = '';
+
+		const onAbort = () => child.kill('SIGTERM');
+		abortSignal?.addEventListener('abort', onAbort);
+
+		child.stdout.on('data', (d) => {
+			stdout += d.toString();
+		});
+		child.stderr.on('data', (d) => {
+			stderr += d.toString();
+		});
+		child.on('error', (err) => {
+			abortSignal?.removeEventListener('abort', onAbort);
+			reject(err);
+		});
+		child.on('close', (code) => {
+			abortSignal?.removeEventListener('abort', onAbort);
+			if (code !== 0) {
+				reject(new AgentError(`Claude bridge failed (code ${code}): ${stderr || stdout}`));
+				return;
+			}
+			try {
+				resolve(JSON.parse(stdout.trim()) as ClaudeBridgeResponse);
+			} catch (err) {
+				reject(new AgentError(`Failed to parse Claude bridge output: ${String(err)}`));
+			}
+		});
+	});
+}
+
+export async function runClaudeCodingSubagent(
+	options: RunClaudeSubagentOptions,
+): Promise<SubagentResult> {
+	const { config, context, hooks, abortSignal, session } = options;
+	const maxSteps = config.maxSteps ?? 8;
+	let stepCount = 0;
+	let prompt = buildClaudeTaskPrompt(context);
+	let sessionId: string | undefined;
+
+	try {
+		for (let i = 0; i < maxSteps; i++) {
+			stepCount++;
+			const turn = await runBridgeTurn({ prompt, sessionId, config }, abortSignal);
+			sessionId = turn.sessionId ?? sessionId;
+
+			hooks.onSubagentStep?.({
+				subagentName: config.name,
+				stepNumber: stepCount,
+				toolCalls: ['claude_code_turn'],
+				tokensUsed: 0,
+			});
+
+			if (turn.isError) {
+				throw new AgentError(turn.error ?? 'Claude bridge returned error');
+			}
+
+			const status = turn.structuredOutput?.status;
+			if (status === 'needs_input') {
+				if (!session) {
+					throw new AgentError(
+						'Claude subagent requested user input but no interactive session exists',
+					);
+				}
+				const question =
+					turn.structuredOutput?.question ??
+					turn.structuredOutput?.message ??
+					'Can you clarify your request?';
+				session.sendToUser({ type: 'question', text: question, blocking: true });
+				prompt = await session.waitForInput();
+				continue;
+			}
+
+			const message = turn.structuredOutput?.message ?? turn.assistantText ?? '';
+			const result: SubagentResult = { text: message, stepCount };
+			session?.complete(result);
+			return result;
+		}
+	} catch (err) {
+		session?.cancel();
+		throw err;
+	}
+
+	session?.cancel();
+	throw new AgentError(`Claude subagent exceeded maxSteps (${maxSteps}) without completion`);
+}

--- a/src/agent/python/claude_sdk_bridge.py
+++ b/src/agent/python/claude_sdk_bridge.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+import asyncio
+import json
+import sys
+
+from claude_agent_sdk import ClaudeAgentOptions, query
+from claude_agent_sdk.types import AssistantMessage, ResultMessage, TextBlock
+
+
+async def run(payload: dict):
+    cfg = payload.get("config", {})
+    options = ClaudeAgentOptions(
+        system_prompt=(
+            payload.get("subagentInstructions", "")
+            + "\n\nYou must return strict JSON matching this schema:"
+            + '{"status":"completed|needs_input","message":"string","question":"string|null"}'
+            + "\nUse status=needs_input only if user input is required before you can continue."
+        ),
+        model=cfg.get("model"),
+        permission_mode=cfg.get("permissionMode"),
+        allowed_tools=cfg.get("allowedTools", []),
+        max_turns=cfg.get("maxTurns"),
+        cwd=cfg.get("cwd"),
+        continue_conversation=bool(payload.get("sessionId")),
+        resume=payload.get("sessionId"),
+        output_format={
+            "type": "json_schema",
+            "name": "subagent_response",
+            "schema": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "status": {"type": "string", "enum": ["completed", "needs_input"]},
+                    "message": {"type": "string"},
+                    "question": {"type": ["string", "null"]},
+                },
+                "required": ["status", "message", "question"],
+            },
+        },
+    )
+
+    assistant_text = ""
+    session_id = payload.get("sessionId")
+    structured_output = None
+
+    async for message in query(prompt=payload["prompt"], options=options):
+        if isinstance(message, AssistantMessage):
+            text_parts = [block.text for block in message.content if isinstance(block, TextBlock)]
+            if text_parts:
+                assistant_text = "\n".join(text_parts)
+        elif isinstance(message, ResultMessage):
+            session_id = message.session_id
+            if message.structured_output is not None:
+                structured_output = message.structured_output
+            elif message.result:
+                try:
+                    structured_output = json.loads(message.result)
+                except Exception:
+                    pass
+
+    return {
+        "sessionId": session_id,
+        "assistantText": assistant_text,
+        "structuredOutput": structured_output,
+        "isError": False,
+    }
+
+
+def main():
+    try:
+        payload = json.loads(sys.argv[1])
+    except Exception as exc:
+        print(json.dumps({"isError": True, "error": f"invalid payload: {exc}"}))
+        sys.exit(1)
+
+    try:
+        result = asyncio.run(run(payload))
+        print(json.dumps(result))
+    except Exception as exc:
+        print(json.dumps({"isError": True, "error": str(exc)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent/subagent-runner.ts
+++ b/src/agent/subagent-runner.ts
@@ -5,8 +5,9 @@ import { generateText, tool } from 'ai';
 import { z } from 'zod';
 import { DEFAULT_SUBAGENT_TIMEOUT_MS } from '../core/constants.js';
 import type { HooksManager } from '../core/hooks.js';
-import type { SubagentConfig } from '../types/agent.js';
+import type { ClaudeCodingSubagentConfig, SubagentConfig } from '../types/agent.js';
 import type { SubagentContextSnapshot, SubagentResult } from '../types/conversation.js';
+import { runClaudeCodingSubagent } from './claude-subagent-runner.js';
 import { InputTimeoutError } from './subagent-session.js';
 import type { InteractiveSubagentConfig, SubagentSession } from './subagent-session.js';
 
@@ -106,6 +107,17 @@ export function createAskUserTool(session: SubagentSession, maxInputRetries: num
  */
 export async function runSubagent(options: RunSubagentOptions): Promise<SubagentResult> {
 	const { config, context, hooks, model, abortSignal, session } = options;
+
+	if (config.runtime === 'claude_code') {
+		return runClaudeCodingSubagent({
+			config: config as ClaudeCodingSubagentConfig,
+			context,
+			hooks,
+			abortSignal,
+			session,
+		});
+	}
+
 	const maxSteps = config.maxSteps ?? 5;
 	const timeoutMs = config.timeout ?? DEFAULT_SUBAGENT_TIMEOUT_MS;
 

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -70,6 +70,24 @@ export interface SubagentConfig {
 	model?: string;
 	/** When true, a SubagentSession with user interaction capabilities is created. */
 	interactive?: boolean;
+	/** Execution runtime for this subagent. Defaults to `ai_sdk`. */
+	runtime?: 'ai_sdk' | 'claude_code';
+}
+
+/** Claude Code specific options used when `runtime: 'claude_code'`. */
+export interface ClaudeCodingOptions {
+	pythonBin?: string;
+	bridgeScriptPath?: string;
+	cwd?: string;
+	model?: string;
+	permissionMode?: 'default' | 'acceptEdits' | 'bypassPermissions';
+	allowedTools?: string[];
+	maxTurns?: number;
+}
+
+export interface ClaudeCodingSubagentConfig extends SubagentConfig {
+	runtime: 'claude_code';
+	claude?: ClaudeCodingOptions;
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,8 @@ export type { BehaviorCategory, BehaviorPreset } from './behavior.js';
 
 export type {
 	AgentContext,
+	ClaudeCodingOptions,
+	ClaudeCodingSubagentConfig,
 	EventSourceConfig,
 	ExternalEvent,
 	MainAgent,


### PR DESCRIPTION
### Motivation

- Enable background subagent handoffs to Anthropic Claude Code via `claude-agent-sdk-python` so coding-focused subagents can run as an alternative runtime and interact with users mid-task. 

### Description

- Add `runtime?: 'ai_sdk' | 'claude_code'` to `SubagentConfig`, introduce `ClaudeCodingOptions` and `ClaudeCodingSubagentConfig` types, and export them from the public types barrel. 
- Route `runtime: 'claude_code'` in `runSubagent()` to a new `runClaudeCodingSubagent()` implementation instead of the default Vercel AI SDK path. 
- Implement `runClaudeCodingSubagent()` in `src/agent/claude-subagent-runner.ts` which invokes a Python bridge per turn, preserves a Claude `sessionId` across turns, detects a structured `needs_input` response, relays concise clarification questions via the existing `SubagentSession` interactive API, and completes/cancels sessions in accordance with existing lifecycle semantics. 
- Add an embedded Python bridge (`src/agent/python/claude_sdk_bridge.py`) that calls `claude-agent-sdk-python`'s `query()` with a JSON-schema `output_format` contract to surface `status`, `message`, and `question` to the TypeScript runtime. 
- Update docs and README (`docs/advanced/subagents.md`, new `docs/advanced/claude-coding-subagent.md`, `README.md`) describing runtime usage, supported capabilities, and known limitations (streaming, hooks/MCP wiring, interrupts, telemetry). 

### Testing

- Ran the targeted integration/unit test with `pnpm -s test test/agent/subagent-runner.test.ts`, which passed (`17 tests, 17 passed`).
- Type-checked the repository with `pnpm -s tsc -p tsconfig.json --noEmit`, which completed successfully.
- Ran code quality checks with `pnpm -s biome check` and applied format/import fixes; checks passed and pre-commit lint/typecheck hooks also passed during the commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acf8e6667483258d3f2d6c8fe448a8)