### PR TITLE
Add Claude Code CLI subagent runtime with interactive handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Main Agent: "Done! The script is saved as hn_scraper.py..."  ← announces resul
 
 ## Features
 
-- **Background subagents**: Mark any tool as `execution: 'background'` — it hands off to a Vercel AI SDK subagent with its own tool-use loop (`maxSteps`), running in parallel while the voice agent continues the conversation. Subagents can be **interactive** — asking the user follow-up questions via voice mid-task
+- **Background subagents**: Mark any tool as `execution: 'background'` — it hands off to a background runtime (`ai_sdk` by default, or `claude_code` via Claude Code CLI). Subagents can be **interactive** — asking the user follow-up questions via voice mid-task
 - **Real-time voice**: Bidirectional audio streaming with Gemini Live API, server-side VAD and turn detection
 - **Multi-agent transfers**: Define specialist agents with distinct personas and tools; transfer mid-conversation with context replay and audio buffering
 - **Inline + background tools**: `inline` tools block the turn (fast lookups); `background` tools run async (image/video generation, data analysis)

--- a/docs/advanced/claude-coding-subagent.md
+++ b/docs/advanced/claude-coding-subagent.md
@@ -1,0 +1,57 @@
+# Claude Coding Subagent (Claude Code CLI)
+
+This page captures what this framework can support today by integrating Claude Code CLI as a background subagent runtime, plus limitations and a comparison with PR #4.
+
+## What is supported
+
+- **MainAgent → Claude coding subagent handoff** using `SubagentConfig.runtime = 'claude_code'`.
+- **Interactive user clarification loop** through existing `SubagentSession` plumbing:
+  - Claude subagent can return `{"status":"needs_input", ...}`.
+  - Framework relays question to the user via voice.
+  - User reply is sent back to Claude as next turn context.
+- **Configurable Claude execution options**:
+  - command path (`command`), `cwd`, `model`, `permissionMode`, `allowedTools`, `maxTurns`, `extraArgs`.
+- **Lifecycle and cancellation integration**:
+  - Shares framework timeout/abort wiring and terminal session transitions.
+  - Emits `onSubagentStep` hook events per Claude CLI turn.
+
+## What is not fully supported (yet)
+
+- **Persistent Claude CLI process / streaming session**.
+  - Current runtime executes Claude CLI per turn (request/response style), not a long-lived interactive TTY.
+- **Token-level streaming relay** from Claude to user.
+  - Turn-level results only.
+- **Native framework mapping of Claude-specific telemetry** (token/cost/latency breakdown).
+  - `onSubagentStep.tokensUsed` is currently `0` placeholder for this runtime.
+- **Hard guarantee of schema compliance**.
+  - Runtime instructs Claude to return strict JSON; malformed JSON returns an error.
+- **First-class support for every CLI feature**.
+  - Framework currently maps only commonly useful coding-runtime flags listed above.
+
+## Comparison with PR #4
+
+PR #4 implemented a Claude runtime through a Python bridge (`claude-agent-sdk-python`) and persisted SDK `session_id` across turns.
+
+### Pros of this CLI-based implementation
+
+- **Fewer runtime dependencies** for Node-first users (no Python bridge script required by default).
+- **Simpler operational model** for teams already standardizing on Claude Code CLI.
+- **Direct parity with CLI permissions/tool flags** exposed to users via `SubagentConfig.claude`.
+
+### Cons vs PR #4
+
+- **No SDK-level session resume primitive** (PR #4 used `resume/session_id`).
+- **No direct access to Python SDK-specific capabilities** (hooks, richer typed messages, SDK MCP wiring).
+- **Less deterministic structured-output handling** than an SDK API with explicit typed result channels.
+
+### Pros of PR #4 (Python bridge)
+
+- Better support for **stateful continuation** with explicit SDK session resume.
+- Easier path to **SDK-level advanced controls** (interrupt APIs, richer metadata).
+- Potentially cleaner integration for **strict structured output** depending on SDK guarantees.
+
+### Cons of PR #4
+
+- Added **Python runtime dependency** and bridge maintenance burden.
+- More moving parts (TypeScript ↔ Python process contract).
+- Operational complexity for environments that only expect Node tooling.

--- a/docs/advanced/subagents.md
+++ b/docs/advanced/subagents.md
@@ -184,6 +184,32 @@ Events can be `normal` or `urgent`:
 | `normal` | Notification queued, delivered at next turn boundary |
 | `urgent` | May interrupt the current turn to notify immediately |
 
+
+## Claude Coding Runtime
+
+You can run a subagent with Claude Code CLI by setting `runtime: "claude_code"`:
+
+```typescript
+const claudeCodingSubagent: SubagentConfig = {
+  name: 'claude_coder',
+  runtime: 'claude_code',
+  interactive: true,
+  instructions: 'You are a senior coding agent. Ask concise clarifying questions when needed.',
+  tools: {}, // Not used by claude_code runtime
+  maxSteps: 8,
+  claude: {
+    command: 'claude',
+    cwd: '/path/to/repo',
+    model: 'claude-sonnet-4-5',
+    permissionMode: 'acceptEdits',
+    allowedTools: ['Read', 'Write', 'Edit', 'Bash', 'Glob', 'Grep'],
+    maxTurns: 8,
+  },
+};
+```
+
+See `docs/advanced/claude-coding-subagent.md` for capability and limitation details.
+
 ## SubagentConfig Reference
 
 ```typescript
@@ -194,6 +220,16 @@ interface SubagentConfig {
   maxSteps?: number;      // Max LLM steps (default 5)
   timeout?: number;       // Execution timeout in ms
   model?: string;         // Override session model
+  runtime?: 'ai_sdk' | 'claude_code';
+  claude?: {
+    command?: string;
+    cwd?: string;
+    model?: string;
+    permissionMode?: 'default' | 'acceptEdits' | 'bypassPermissions';
+    allowedTools?: string[];
+    maxTurns?: number;
+    extraArgs?: string[];
+  };
 }
 ```
 

--- a/src/agent/claude-subagent-runner.ts
+++ b/src/agent/claude-subagent-runner.ts
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: MIT
+
+import { spawn } from 'node:child_process';
+import { AgentError } from '../core/errors.js';
+import type { HooksManager } from '../core/hooks.js';
+import type { ClaudeCodeSubagentConfig } from '../types/agent.js';
+import type { SubagentContextSnapshot, SubagentResult } from '../types/conversation.js';
+import type { SubagentSession } from './subagent-session.js';
+
+export interface RunClaudeCodeSubagentOptions {
+	config: ClaudeCodeSubagentConfig;
+	context: SubagentContextSnapshot;
+	hooks: HooksManager;
+	abortSignal?: AbortSignal;
+	session?: SubagentSession;
+}
+
+interface ClaudeSubagentContract {
+	status: 'completed' | 'needs_input';
+	message: string;
+	question?: string | null;
+}
+
+function buildClaudePrompt(context: SubagentContextSnapshot): string {
+	const parts: string[] = [
+		`Task: ${context.task.description}`,
+		`Task arguments: ${JSON.stringify(context.task.args, null, 2)}`,
+		`Subagent instructions: ${context.agentInstructions}`,
+		'You are running as a coding subagent. Return ONLY strict JSON that matches this schema:',
+		'{"status":"completed|needs_input","message":"string","question":"string|null"}',
+		'Use needs_input only when a user clarification is required before you can continue.',
+	];
+
+	if (context.conversationSummary) {
+		parts.push(`Conversation summary: ${context.conversationSummary}`);
+	}
+	if (context.recentTurns.length > 0) {
+		parts.push(
+			`Recent turns:\n${context.recentTurns.map((turn) => `[${turn.role}] ${turn.content}`).join('\n')}`,
+		);
+	}
+
+	return parts.join('\n\n');
+}
+
+function parseStructuredFromText(text: string): ClaudeSubagentContract {
+	const trimmed = text.trim();
+	if (trimmed.length === 0) {
+		throw new AgentError('Claude CLI returned empty output');
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(trimmed);
+	} catch {
+		const maybeJson = trimmed
+			.split('\n')
+			.map((line) => line.trim())
+			.filter(Boolean)
+			.find((line) => line.startsWith('{') && line.endsWith('}'));
+		if (!maybeJson) {
+			throw new AgentError('Claude CLI output is not valid JSON for subagent contract');
+		}
+		parsed = JSON.parse(maybeJson);
+	}
+
+	const obj = parsed as Record<string, unknown>;
+	const status = obj.status;
+	const message = obj.message;
+	const question = obj.question;
+	if ((status !== 'completed' && status !== 'needs_input') || typeof message !== 'string') {
+		throw new AgentError('Claude CLI JSON does not match expected subagent contract');
+	}
+	if (question !== undefined && question !== null && typeof question !== 'string') {
+		throw new AgentError('Claude CLI JSON question must be string|null when present');
+	}
+
+	return {
+		status,
+		message,
+		question: question === undefined ? null : question,
+	};
+}
+
+async function runClaudeCliTurn(
+	config: ClaudeCodeSubagentConfig,
+	prompt: string,
+	abortSignal?: AbortSignal,
+): Promise<ClaudeSubagentContract> {
+	const command = config.claude?.command ?? 'claude';
+	const args: string[] = ['-p', prompt, '--output-format', 'json'];
+
+	if (config.claude?.model) {
+		args.push('--model', config.claude.model);
+	}
+	if (config.claude?.permissionMode) {
+		args.push('--permission-mode', config.claude.permissionMode);
+	}
+	if (config.claude?.allowedTools && config.claude.allowedTools.length > 0) {
+		args.push('--allowedTools', config.claude.allowedTools.join(','));
+	}
+	if (config.claude?.maxTurns) {
+		args.push('--max-turns', String(config.claude.maxTurns));
+	}
+	if (config.claude?.extraArgs && config.claude.extraArgs.length > 0) {
+		args.push(...config.claude.extraArgs);
+	}
+
+	const output = await new Promise<string>((resolve, reject) => {
+		const child = spawn(command, args, {
+			cwd: config.claude?.cwd,
+			stdio: ['ignore', 'pipe', 'pipe'],
+		});
+
+		let stdout = '';
+		let stderr = '';
+
+		const onAbort = () => child.kill('SIGTERM');
+		abortSignal?.addEventListener('abort', onAbort);
+
+		child.stdout.on('data', (chunk) => {
+			stdout += chunk.toString();
+		});
+		child.stderr.on('data', (chunk) => {
+			stderr += chunk.toString();
+		});
+
+		child.on('error', (err) => {
+			abortSignal?.removeEventListener('abort', onAbort);
+			reject(new AgentError(`Failed to launch Claude CLI: ${err.message}`));
+		});
+
+		child.on('close', (code) => {
+			abortSignal?.removeEventListener('abort', onAbort);
+			if (code !== 0) {
+				reject(new AgentError(`Claude CLI failed (code ${code}): ${stderr || stdout}`));
+				return;
+			}
+			resolve(stdout);
+		});
+	});
+
+	return parseStructuredFromText(output);
+}
+
+export async function runClaudeCodeSubagent(
+	options: RunClaudeCodeSubagentOptions,
+): Promise<SubagentResult> {
+	const { config, context, hooks, abortSignal, session } = options;
+	const maxSteps = config.maxSteps ?? 6;
+	let prompt = buildClaudePrompt(context);
+
+	for (let step = 1; step <= maxSteps; step++) {
+		const turn = await runClaudeCliTurn(config, prompt, abortSignal);
+
+		hooks.onSubagentStep?.({
+			subagentName: config.name,
+			stepNumber: step,
+			toolCalls: ['claude_cli_turn'],
+			tokensUsed: 0,
+		});
+
+		if (turn.status === 'needs_input') {
+			if (!session) {
+				throw new AgentError(
+					'Claude subagent requested input but no interactive session is available',
+				);
+			}
+
+			const question = turn.question ?? turn.message;
+			session.sendToUser({ type: 'question', text: question, blocking: true });
+			const userReply = await session.waitForInput();
+			prompt = [
+				'Continue the same task based on the user clarification below.',
+				`User clarification: ${userReply}`,
+				'Return strict JSON matching the same schema.',
+			].join('\n\n');
+			continue;
+		}
+
+		const result: SubagentResult = { text: turn.message, stepCount: step };
+		session?.complete(result);
+		return result;
+	}
+
+	session?.cancel();
+	throw new AgentError(`Claude subagent exceeded maxSteps (${maxSteps}) without completion`);
+}
+
+export { buildClaudePrompt as _buildClaudePromptForTest };

--- a/src/agent/subagent-runner.ts
+++ b/src/agent/subagent-runner.ts
@@ -5,8 +5,9 @@ import { generateText, tool } from 'ai';
 import { z } from 'zod';
 import { DEFAULT_SUBAGENT_TIMEOUT_MS } from '../core/constants.js';
 import type { HooksManager } from '../core/hooks.js';
-import type { SubagentConfig } from '../types/agent.js';
+import type { ClaudeCodeSubagentConfig, SubagentConfig } from '../types/agent.js';
 import type { SubagentContextSnapshot, SubagentResult } from '../types/conversation.js';
+import { runClaudeCodeSubagent } from './claude-subagent-runner.js';
 import { InputTimeoutError } from './subagent-session.js';
 import type { InteractiveSubagentConfig, SubagentSession } from './subagent-session.js';
 
@@ -106,6 +107,16 @@ export function createAskUserTool(session: SubagentSession, maxInputRetries: num
  */
 export async function runSubagent(options: RunSubagentOptions): Promise<SubagentResult> {
 	const { config, context, hooks, model, abortSignal, session } = options;
+
+	if (config.runtime === 'claude_code') {
+		return runClaudeCodeSubagent({
+			config: config as ClaudeCodeSubagentConfig,
+			context,
+			hooks,
+			abortSignal,
+			session,
+		});
+	}
 	const maxSteps = config.maxSteps ?? 5;
 	const timeoutMs = config.timeout ?? DEFAULT_SUBAGENT_TIMEOUT_MS;
 

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -70,6 +70,31 @@ export interface SubagentConfig {
 	model?: string;
 	/** When true, a SubagentSession with user interaction capabilities is created. */
 	interactive?: boolean;
+	/** Runtime used for execution. Defaults to `ai_sdk` (Vercel AI SDK). */
+	runtime?: 'ai_sdk' | 'claude_code';
+}
+
+/** Claude Code CLI specific options used when `runtime: 'claude_code'`. */
+export interface ClaudeCodeSubagentOptions {
+	/** CLI command path. Defaults to `claude`. */
+	command?: string;
+	/** Optional working directory for the Claude process. */
+	cwd?: string;
+	/** Model passed through to Claude CLI (`--model`). */
+	model?: string;
+	/** Permission mode passed to Claude CLI (`--permission-mode`). */
+	permissionMode?: 'default' | 'acceptEdits' | 'bypassPermissions';
+	/** Optional allow-list for tools (`--allowedTools`). */
+	allowedTools?: string[];
+	/** Max turns handled by Claude per invocation (`--max-turns`). */
+	maxTurns?: number;
+	/** Extra args appended verbatim after framework-managed args. */
+	extraArgs?: string[];
+}
+
+export interface ClaudeCodeSubagentConfig extends SubagentConfig {
+	runtime: 'claude_code';
+	claude?: ClaudeCodeSubagentOptions;
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,8 @@ export type { BehaviorCategory, BehaviorPreset } from './behavior.js';
 
 export type {
 	AgentContext,
+	ClaudeCodeSubagentConfig,
+	ClaudeCodeSubagentOptions,
 	EventSourceConfig,
 	ExternalEvent,
 	MainAgent,

--- a/test/agent/claude-subagent-runner.test.ts
+++ b/test/agent/claude-subagent-runner.test.ts
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT
+
+import { EventEmitter } from 'node:events';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { runClaudeCodeSubagent } from '../../src/agent/claude-subagent-runner.js';
+import { SubagentSessionImpl } from '../../src/agent/subagent-session.js';
+import { HooksManager } from '../../src/core/hooks.js';
+import type { SubagentContextSnapshot } from '../../src/types/conversation.js';
+
+interface FakeChild extends EventEmitter {
+	stdout: EventEmitter;
+	stderr: EventEmitter;
+	kill: (signal?: string) => void;
+}
+
+const { spawnMock } = vi.hoisted(() => ({
+	spawnMock: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+	spawn: spawnMock,
+}));
+
+function createContext(): SubagentContextSnapshot {
+	return {
+		task: {
+			description: 'Write a TypeScript utility',
+			toolCallId: 'tc_1',
+			toolName: 'ask_claude',
+			args: { file: 'util.ts' },
+		},
+		conversationSummary: null,
+		recentTurns: [],
+		relevantMemoryFacts: [],
+		agentInstructions: 'You are a coding agent.',
+	};
+}
+
+function mockSpawnWithOutputs(outputs: Array<{ code: number; stdout: string; stderr?: string }>) {
+	let idx = 0;
+	spawnMock.mockImplementation(() => {
+		const child = new EventEmitter() as FakeChild;
+		child.stdout = new EventEmitter();
+		child.stderr = new EventEmitter();
+		child.kill = vi.fn();
+		const out = outputs[idx++];
+		setTimeout(() => {
+			if (out.stdout) child.stdout.emit('data', out.stdout);
+			if (out.stderr) child.stderr.emit('data', out.stderr);
+			child.emit('close', out.code);
+		}, 0);
+		return child;
+	});
+}
+
+beforeEach(() => {
+	spawnMock.mockReset();
+});
+describe('runClaudeCodeSubagent', () => {
+	it('returns completed result from Claude JSON contract', async () => {
+		mockSpawnWithOutputs([{ code: 0, stdout: '{"status":"completed","message":"Done"}' }]);
+
+		const hooks = new HooksManager();
+		const result = await runClaudeCodeSubagent({
+			config: {
+				name: 'claude-coder',
+				runtime: 'claude_code',
+				instructions: 'Code',
+				tools: {},
+			},
+			context: createContext(),
+			hooks,
+		});
+
+		expect(result).toEqual({ text: 'Done', stepCount: 1 });
+		expect(spawnMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('supports interactive needs_input loop via SubagentSession', async () => {
+		mockSpawnWithOutputs([
+			{
+				code: 0,
+				stdout: '{"status":"needs_input","message":"Need filename","question":"What file name?"}',
+			},
+			{ code: 0, stdout: '{"status":"completed","message":"Created helper"}' },
+		]);
+
+		const session = new SubagentSessionImpl('tc_1', {
+			name: 'claude-coder',
+			instructions: 'Code',
+			tools: {},
+			interactive: true,
+		});
+		session.onMessage((msg) => {
+			if (msg.type === 'question') {
+				setTimeout(() => session.sendToSubagent('Use src/helper.ts'), 0);
+			}
+		});
+
+		const result = await runClaudeCodeSubagent({
+			config: {
+				name: 'claude-coder',
+				runtime: 'claude_code',
+				instructions: 'Code',
+				tools: {},
+				interactive: true,
+			},
+			context: createContext(),
+			hooks: new HooksManager(),
+			session,
+		});
+
+		expect(result.text).toBe('Created helper');
+		expect(result.stepCount).toBe(2);
+		expect(spawnMock).toHaveBeenCalledTimes(2);
+		expect(session.state).toBe('completed');
+	});
+
+	it('throws when Claude output is invalid JSON', async () => {
+		mockSpawnWithOutputs([{ code: 0, stdout: 'not-json' }]);
+
+		await expect(
+			runClaudeCodeSubagent({
+				config: {
+					name: 'claude-coder',
+					runtime: 'claude_code',
+					instructions: 'Code',
+					tools: {},
+				},
+				context: createContext(),
+				hooks: new HooksManager(),
+			}),
+		).rejects.toThrow('not valid JSON');
+	});
+});


### PR DESCRIPTION
### Motivation
- Add support for running coding subagents using the Claude Code CLI so MainAgent can delegate multi-turn coding tasks to a Claude runtime and still handle interactive user clarification mid-task.
- Provide a pragmatic, Node-first runtime alternative to the previously proposed Python SDK bridge while exposing configurable CLI options and preserving the existing `SubagentSession` interactive flow.

### Description
- Introduced a new Claude runtime dispatch path in `runSubagent` that routes `SubagentConfig` entries with `runtime: 'claude_code'` to a new `runClaudeCodeSubagent` implementation. (files: `src/agent/subagent-runner.ts`, `src/agent/claude-subagent-runner.ts`)
- Implemented `runClaudeCodeSubagent` which spawns the Claude CLI, assembles prompts, enforces a strict JSON turn contract (`completed | needs_input`), bridges `needs_input` through `SubagentSession.sendToUser()` / `waitForInput()`, emits `onSubagentStep` hooks, and handles abort/cancellation. (file: `src/agent/claude-subagent-runner.ts`)
- Extended types with `runtime` and Claude-specific options and exported them from the types barrel: `ClaudeCodeSubagentConfig` / `ClaudeCodeSubagentOptions`. (files: `src/types/agent.ts`, `src/types/index.ts`)
- Added docs describing capabilities, limitations, usage examples, and a comparison to the Python bridge approach from the referenced PR. (files: `docs/advanced/claude-coding-subagent.md`, `docs/advanced/subagents.md`, `README.md`)
- Added unit tests for the Claude runner (completion, interactive `needs_input` loop, and malformed output) and minor test harness adjustments. (file: `test/agent/claude-subagent-runner.test.ts`)

### Testing
- Ran the targeted unit tests with `pnpm vitest run test/agent/claude-subagent-runner.test.ts test/agent/subagent-runner.test.ts` and both test files passed. 
- Ran type checking with `pnpm typecheck` and lint with `pnpm lint` (and fixed formatting with `pnpm lint:fix`), both succeeded after fixes. 
- Note: attempted to fetch the official Claude CLI docs (`https://code.claude.com/docs/en/cli-reference`) but the environment blocked the request (HTTP CONNECT 403), so CLI argument mapping was implemented conservatively using available upstream repo/docs and validated via unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad0ad4dd148325b756b752e336618e)