### PR TITLE
feat: add Codex coding subagent support with interactive turn relay

### DIFF
--- a/docs/advanced/subagents.md
+++ b/docs/advanced/subagents.md
@@ -224,3 +224,46 @@ hooks: {
   },
 }
 ```
+
+
+## Codex Coding Subagent (Experimental)
+
+You can run a background subagent with Codex by setting `provider: "codex"` in `SubagentConfig`.
+The framework uses `@openai/codex-sdk` to start a Codex thread and stream progress items.
+
+```typescript
+const codingSubagent: SubagentConfig = {
+  name: 'codex_coder',
+  provider: 'codex',
+  instructions: 'You are a careful coding assistant. Make minimal, tested changes.',
+  tools: {}, // unused by Codex provider
+  interactive: true,
+  codex: {
+    model: 'gpt-5-codex',
+    sandboxMode: 'workspace-write',
+    approvalPolicy: 'never',
+    workingDirectory: process.cwd(),
+    networkAccessEnabled: true,
+  },
+};
+```
+
+### What works well
+
+- File editing and patch application in the repository.
+- Shell command execution and progress streaming to the user.
+- Multi-turn coding sessions when `interactive: true` (MainAgent can relay follow-up instructions to the same Codex thread).
+
+### Current limitations
+
+- Codex provider does **not** consume Vercel AI SDK `tools` (`config.tools` is ignored).
+- No native `ask_user` tool inside Codex turns; interaction is orchestrated at turn boundaries by the framework.
+- Token accounting in `onSubagentStep` is currently reported as `0` for Codex events.
+
+### Can it support an email-sending skill?
+
+Yes, but with caveats:
+
+- **Possible now**: configure an MCP server (or CLI/script) that sends email, and let Codex call it during a turn.
+- **Not automatic**: this framework does not inject a first-class `send_email` tool into Codex the way AI SDK tools are injected for `provider: "ai-sdk"`.
+- **Recommended safety**: keep approval policy strict (`on-request`/`untrusted`) for side-effectful tools like sending email.

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "dependencies": {
     "@ai-sdk/google": "^1.2.0",
     "@google/genai": "^1.41.0",
+    "@openai/codex-sdk": "^0.111.0",
     "ai": "^4.3.0",
     "dotenv": "^17.3.1",
     "openai": "^6.25.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@google/genai':
         specifier: ^1.41.0
         version: 1.41.0
+      '@openai/codex-sdk':
+        specifier: ^0.111.0
+        version: 0.111.0
       ai:
         specifier: ^4.3.0
         version: 4.3.19(react@19.2.4)(zod@3.25.76)
@@ -640,6 +643,51 @@ packages:
 
   '@mermaid-js/parser@0.6.3':
     resolution: {integrity: sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==}
+
+  '@openai/codex-sdk@0.111.0':
+    resolution: {integrity: sha512-f2PwDGZfw5PSlD49T+Bh3ozEx2SwDaJFiETnPA+amDYeTTTp71RmBCLwg0MDlNJY3clBlpdh9IMkeGY+D008ng==}
+    engines: {node: '>=18'}
+
+  '@openai/codex@0.111.0':
+    resolution: {integrity: sha512-69Mw8//xBEHIgQ11tlYbz7HI2kndOs9GNnMVGzmTgsR48x2ZyYiZR1n4z2M+aR0A9BoarGxPIcbu2aEzVP/L0g==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  '@openai/codex@0.111.0-darwin-arm64':
+    resolution: {integrity: sha512-g8QkNUqacCUs7aU/Yd+gtiDlVV6sYyQl9tjBGgwjdfHCdmSKD47tD2tWRugXZ4D/uEe/6RxlUv65JnU5V0PW8A==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@openai/codex@0.111.0-darwin-x64':
+    resolution: {integrity: sha512-WfjErI0IWMSu17XoiPstvph6MX2wFZd9zrwKCWkYLrN68mNYKfBgZE7pSCb9Z3nxVMbaphq8jhf0kImCWCsatQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@openai/codex@0.111.0-linux-arm64':
+    resolution: {integrity: sha512-/ABn3UhcbnJEhRNUH/BUcG/lr2n/CeacyXORWpHScNkkjMPUOkyNudUOyuoZjwybHU2PAmbpLIf5exXVNRvu2g==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@openai/codex@0.111.0-linux-x64':
+    resolution: {integrity: sha512-Cj82IUWtHkqMw3JpODGnkL9lyHhGLIAMHU9+3CosKLtOHUB4A9W3zKEBJrrlsi6QruvYVWrb/7t/xGb82fna0Q==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@openai/codex@0.111.0-win32-arm64':
+    resolution: {integrity: sha512-h6WaA/ixD9ucwcmSUbXpjmhyfptD6Yk3N2IynNjOCvqgXS3V7uaNTm6qHFgkvA9S2IbkS9gA+ydgxFVyU6w7eQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@openai/codex@0.111.0-win32-x64':
+    resolution: {integrity: sha512-jWCcI8Nv8kpr29VWmTrNpRw9zMGAc4sqy94mw13OgOcFcDtnuqdjtaJAswKHrZZbdT+kqDDZmi7Gvi/vsahvDA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -2821,6 +2869,37 @@ snapshots:
   '@mermaid-js/parser@0.6.3':
     dependencies:
       langium: 3.3.1
+
+  '@openai/codex-sdk@0.111.0':
+    dependencies:
+      '@openai/codex': 0.111.0
+
+  '@openai/codex@0.111.0':
+    optionalDependencies:
+      '@openai/codex-darwin-arm64': '@openai/codex@0.111.0-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.111.0-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.111.0-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.111.0-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.111.0-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.111.0-win32-x64'
+
+  '@openai/codex@0.111.0-darwin-arm64':
+    optional: true
+
+  '@openai/codex@0.111.0-darwin-x64':
+    optional: true
+
+  '@openai/codex@0.111.0-linux-arm64':
+    optional: true
+
+  '@openai/codex@0.111.0-linux-x64':
+    optional: true
+
+  '@openai/codex@0.111.0-win32-arm64':
+    optional: true
+
+  '@openai/codex@0.111.0-win32-x64':
+    optional: true
 
   '@opentelemetry/api@1.9.0': {}
 

--- a/src/agent/agent-router.ts
+++ b/src/agent/agent-router.ts
@@ -12,6 +12,7 @@ import type { SubagentResult, ToolCall } from '../types/conversation.js';
 import type { ToolDefinition } from '../types/tool.js';
 import type { LLMTransport } from '../types/transport.js';
 import { createAgentContext, resolveInstructions } from './agent-context.js';
+import { runCodexSubagent } from './codex-subagent-runner.js';
 import { runSubagent } from './subagent-runner.js';
 import type { SubagentMessage, SubagentSession } from './subagent-session.js';
 import { SubagentSessionImpl } from './subagent-session.js';
@@ -238,14 +239,23 @@ export class AgentRouter {
 				[],
 			);
 
-			const result = await runSubagent({
-				config: subagentConfig,
-				context,
-				hooks: this.hooks,
-				model: this.model,
-				abortSignal: controller.signal,
-				session,
-			});
+			const result =
+				subagentConfig.provider === 'codex'
+					? await runCodexSubagent({
+							config: subagentConfig,
+							context,
+							hooks: this.hooks,
+							abortSignal: controller.signal,
+							session,
+						})
+					: await runSubagent({
+							config: subagentConfig,
+							context,
+							hooks: this.hooks,
+							model: this.model,
+							abortSignal: controller.signal,
+							session,
+						});
 
 			return result;
 		} finally {

--- a/src/agent/codex-subagent-runner.ts
+++ b/src/agent/codex-subagent-runner.ts
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+
+import { Codex } from '@openai/codex-sdk';
+import type { HooksManager } from '../core/hooks.js';
+import type { SubagentConfig } from '../types/agent.js';
+import type { SubagentContextSnapshot, SubagentResult } from '../types/conversation.js';
+import type { InteractiveSubagentConfig, SubagentSession } from './subagent-session.js';
+
+interface RunCodexSubagentOptions {
+	config: SubagentConfig;
+	context: SubagentContextSnapshot;
+	hooks: HooksManager;
+	abortSignal?: AbortSignal;
+	session?: SubagentSession;
+}
+
+function buildCodexPrompt(context: SubagentContextSnapshot): string {
+	const parts: string[] = [];
+	parts.push(`# Instructions\n${context.agentInstructions}`);
+	parts.push(`\n# Task\n${context.task.description}`);
+
+	if (Object.keys(context.task.args).length > 0) {
+		parts.push(`\n# Task Arguments\n${JSON.stringify(context.task.args, null, 2)}`);
+	}
+	if (context.conversationSummary) {
+		parts.push(`\n# Conversation Summary\n${context.conversationSummary}`);
+	}
+	if (context.recentTurns.length > 0) {
+		const turns = context.recentTurns.map((t) => `[${t.role}]: ${t.content}`).join('\n');
+		parts.push(`\n# Recent Conversation\n${turns}`);
+	}
+	if (context.relevantMemoryFacts.length > 0) {
+		const facts = context.relevantMemoryFacts.map((f) => `- ${f.content}`).join('\n');
+		parts.push(`\n# Relevant Memory\n${facts}`);
+	}
+
+	parts.push('\nUse available coding tools to inspect, edit, and validate changes.');
+	return parts.join('\n');
+}
+
+async function runSingleCodexTurn(
+	thread: ReturnType<Codex['startThread']>,
+	input: string,
+	options: RunCodexSubagentOptions,
+): Promise<{ finalResponse: string; stepCount: number }> {
+	const streamed = await thread.runStreamed(input, { signal: options.abortSignal });
+	let finalResponse = '';
+	let stepCount = 0;
+
+	for await (const event of streamed.events) {
+		if (event.type !== 'item.completed') {
+			continue;
+		}
+
+		stepCount++;
+		if (options.hooks.onSubagentStep) {
+			options.hooks.onSubagentStep({
+				subagentName: options.config.name,
+				stepNumber: stepCount,
+				toolCalls: [event.item.type],
+				tokensUsed: 0,
+			});
+		}
+
+		if (event.item.type === 'agent_message') {
+			finalResponse = event.item.text;
+		}
+		if (options.session && event.item.type === 'command_execution') {
+			options.session.sendToUser({
+				type: 'progress',
+				text: `Codex ran: ${event.item.command}`,
+			});
+		}
+	}
+
+	return { finalResponse, stepCount };
+}
+
+export async function runCodexSubagent(options: RunCodexSubagentOptions): Promise<SubagentResult> {
+	const codex = new Codex({
+		apiKey: options.config.codex?.apiKey,
+		baseUrl: options.config.codex?.baseUrl,
+		config: options.config.codex?.config as never,
+	});
+
+	const thread = codex.startThread({
+		model: options.config.codex?.model,
+		approvalPolicy: options.config.codex?.approvalPolicy,
+		sandboxMode: options.config.codex?.sandboxMode,
+		workingDirectory: options.config.codex?.workingDirectory,
+		networkAccessEnabled: options.config.codex?.networkAccessEnabled,
+		skipGitRepoCheck: options.config.codex?.skipGitRepoCheck,
+	});
+
+	let totalStepCount = 0;
+	let prompt = buildCodexPrompt(options.context);
+	let finalResponse = '';
+
+	while (true) {
+		const turn = await runSingleCodexTurn(thread, prompt, options);
+		totalStepCount += turn.stepCount;
+		finalResponse = turn.finalResponse;
+
+		if (!options.session || !options.config.interactive) {
+			break;
+		}
+
+		options.session.sendToUser({
+			type: 'question',
+			text: `${finalResponse}\n\nProvide follow-up coding instructions, or reply "done" to finish.`,
+			blocking: true,
+		});
+		const followUp = await options.session.waitForInput(
+			(options.config as InteractiveSubagentConfig).inputTimeout,
+		);
+		if (/^\s*(done|stop|no)\s*$/i.test(followUp)) {
+			break;
+		}
+		prompt = followUp;
+	}
+
+	const result: SubagentResult = {
+		text: finalResponse,
+		stepCount: totalStepCount,
+	};
+
+	if (options.session) {
+		options.session.complete(result);
+	}
+
+	return result;
+}
+
+export const _buildCodexPromptForTest = buildCodexPrompt;

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -3,6 +3,7 @@
 export { createAgentContext } from './agent-context.js';
 export { AgentRouter } from './agent-router.js';
 export type { SubagentEventCallbacks } from './agent-router.js';
+export { runCodexSubagent } from './codex-subagent-runner.js';
 export { createAskUserTool, runSubagent } from './subagent-runner.js';
 export type { RunSubagentOptions } from './subagent-runner.js';
 export {

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -68,8 +68,31 @@ export interface SubagentConfig {
 	timeout?: number;
 	/** Override the model used for this subagent (defaults to session model). */
 	model?: string;
+	/** Subagent runtime provider. Defaults to `ai-sdk`. */
+	provider?: 'ai-sdk' | 'codex';
 	/** When true, a SubagentSession with user interaction capabilities is created. */
 	interactive?: boolean;
+	/** Codex runtime options (used when provider is `codex`). */
+	codex?: {
+		/** Optional Codex API key (falls back to environment if omitted). */
+		apiKey?: string;
+		/** Optional base URL for Codex/OpenAI-compatible endpoint. */
+		baseUrl?: string;
+		/** Override model for the Codex thread. */
+		model?: string;
+		/** Codex sandbox mode. */
+		sandboxMode?: 'read-only' | 'workspace-write' | 'danger-full-access';
+		/** Codex approval policy for command execution. */
+		approvalPolicy?: 'untrusted' | 'on-failure' | 'on-request' | 'never';
+		/** Working directory where Codex should run. */
+		workingDirectory?: string;
+		/** Allow network access in workspace-write mode. */
+		networkAccessEnabled?: boolean;
+		/** Skip git repository requirement. */
+		skipGitRepoCheck?: boolean;
+		/** Additional raw Codex CLI config overrides. */
+		config?: Record<string, unknown>;
+	};
 }
 
 /**

--- a/test/agent/codex-subagent-runner.test.ts
+++ b/test/agent/codex-subagent-runner.test.ts
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it, vi } from 'vitest';
+import { runCodexSubagent } from '../../src/agent/codex-subagent-runner.js';
+import { SubagentSessionImpl } from '../../src/agent/subagent-session.js';
+import { HooksManager } from '../../src/core/hooks.js';
+import type { SubagentContextSnapshot } from '../../src/types/conversation.js';
+
+vi.mock('@openai/codex-sdk', () => {
+	const runStreamed = vi.fn(async (input: string) => ({
+		events: (async function* () {
+			yield {
+				type: 'item.completed',
+				item: {
+					type: 'command_execution',
+					command: 'npm test',
+					aggregated_output: '',
+					status: 'completed',
+					id: '1',
+					exit_code: 0,
+				},
+			};
+			yield {
+				type: 'item.completed',
+				item: { type: 'agent_message', text: `done: ${input}`, id: '2' },
+			};
+			yield {
+				type: 'turn.completed',
+				usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 },
+			};
+		})(),
+	}));
+
+	return {
+		Codex: vi.fn(() => ({
+			startThread: vi.fn(() => ({ runStreamed })),
+		})),
+	};
+});
+
+function createContext(): SubagentContextSnapshot {
+	return {
+		task: { description: 'Fix lint', toolCallId: 'tc_1', toolName: 'fix', args: {} },
+		conversationSummary: null,
+		recentTurns: [],
+		relevantMemoryFacts: [],
+		agentInstructions: 'You are a coding assistant',
+	};
+}
+
+describe('runCodexSubagent', () => {
+	it('runs a codex turn and returns the final response', async () => {
+		const result = await runCodexSubagent({
+			config: { name: 'coder', provider: 'codex', instructions: 'code', tools: {} },
+			context: createContext(),
+			hooks: new HooksManager(),
+		});
+
+		expect(result.text).toContain('done:');
+		expect(result.stepCount).toBe(2);
+	});
+
+	it('supports interactive follow-up messages via SubagentSession', async () => {
+		const hooks = new HooksManager();
+		const session = new SubagentSessionImpl('tc_1', { interactive: true, inputTimeout: 1000 });
+		session.onStateChange((next) => {
+			if (next === 'waiting_for_input') {
+				setTimeout(() => session.sendToSubagent('done'), 0);
+			}
+		});
+
+		const result = await runCodexSubagent({
+			config: {
+				name: 'coder',
+				provider: 'codex',
+				instructions: 'code',
+				tools: {},
+				interactive: true,
+			},
+			context: createContext(),
+			hooks,
+			session,
+		});
+
+		expect(result.text).toContain('done:');
+		expect(result.stepCount).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
### Motivation

- Enable running coding-oriented subagents backed by the OpenAI Codex runtime so the MainAgent can offload multi-step code workflows while continuing the voice session. 
- Provide an interactive round-trip so the MainAgent and user can iterate with the coding subagent (follow-up instructions, progress, and final result). 
- Surface a clear integration surface for Codex runtime options (sandboxing, approval policy, working dir) and document capabilities/limitations (including email-sending feasibility).

### Description

- Extended `SubagentConfig` with a `provider?: 'ai-sdk' | 'codex'` field and a `codex` options block to configure model, sandbox mode, approval policy, working directory, network access, and extra CLI config. 
- Implemented `runCodexSubagent()` in `src/agent/codex-subagent-runner.ts` that uses `@openai/codex-sdk` to start a Codex thread, stream `item.completed` events, forward `command_execution` progress to interactive `SubagentSession`s, and support multi-turn follow-ups at turn boundaries. 
- Updated `AgentRouter.handoff()` to dispatch subagent execution to `runCodexSubagent()` when `provider === 'codex'` and to the existing `runSubagent()` otherwise. 
- Exported `runCodexSubagent` from the agent barrel and added `@openai/codex-sdk` to `package.json`. 
- Added docs in `docs/advanced/subagents.md` describing the Codex provider (what works, limitations, and email-sending guidance). 
- Added unit tests for the Codex runner (normal and interactive flows) in `test/agent/codex-subagent-runner.test.ts`.

### Testing

- Ran the unit tests with `pnpm vitest run test/agent/codex-subagent-runner.test.ts test/agent/agent-router.test.ts test/agent/subagent-runner.test.ts` and all targeted tests passed. 
- Performed static checks with `pnpm typecheck` (TS `tsc --noEmit`) which passed after adding the Codex runner typing workaround. 
- Ran lint checks and applied formatting fixes with `pnpm lint:fix`, and pre-commit checks (lint + typecheck) passed during the commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad0f25cc948325aaa039353eb2b9fc)