### PR TITLE
fix(claude-code): support subscription auth without ANTHROPIC_API_KEY

### DIFF
--- a/examples/claude_code/claude-code-client.ts
+++ b/examples/claude_code/claude-code-client.ts
@@ -253,6 +253,7 @@ export class ClaudeCodeSession {
 		];
 
 		const opts: Record<string, unknown> = {
+			pathToClaudeCodeExecutable: process.env.CLAUDE_PATH ?? 'claude',
 			allowedTools,
 			permissionMode: (this.options.permissionMode ?? 'bypassPermissions') as PermissionMode,
 			allowDangerouslySkipPermissions:

--- a/examples/claude_code/claude-demo.ts
+++ b/examples/claude_code/claude-demo.ts
@@ -113,11 +113,6 @@ if (GEMINI_API_KEY.length === 0) {
 	process.exit(1);
 }
 
-const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY ?? '';
-if (ANTHROPIC_API_KEY.length === 0) {
-	console.error('Error: ANTHROPIC_API_KEY environment variable is required');
-	process.exit(1);
-}
 
 const PORT = Number(process.env.PORT) || 9900;
 const HOST = process.env.HOST || '0.0.0.0';


### PR DESCRIPTION
## Summary

Two fixes to make the `claude_code` example work with Claude subscription auth instead of an API key.

### Changes

**`examples/claude_code/claude-demo.ts`**
- Removed the `ANTHROPIC_API_KEY` env var guard. The SDK spawns the Claude CLI directly and never passes the key at runtime — the check was unnecessary and blocked subscription users.

**`examples/claude_code/claude-code-client.ts`**
- Added `pathToClaudeCodeExecutable: process.env.CLAUDE_PATH ?? 'claude'` to `buildOptions()`. Fixes `spawn node ENOENT` crash when `node` is not on the subprocess PATH. Since the Claude binary is a native Mach-O executable, passing it directly via `pathToClaudeCodeExecutable` lets the SDK spawn it without needing `node` in PATH.